### PR TITLE
skip spellcheck of release notes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           # filter out
           #   docs/js/asciinema-player-2.6.1.js as it is not markdown
           #   version-specific/supported-software.md as the software descriptions have spelling errors
-          skip: './docs/js/asciinema-player-2.6.1.js,./docs/version-specific/supported-software.md'
+          skip: './docs/js/asciinema-player-2.6.1.js,./docs/version-specific/supported-software.md,./docs/release-notes.md'
 
       - name: check internal links
         run: python ./.github/workflows/link_check.py


### PR DESCRIPTION
From https://github.com/easybuilders/easybuild-docs/pull/117#issuecomment-1470043281

It makes sense to skip this as it is an auto-generated page